### PR TITLE
Move provider schema descriptions inline and add validation test

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 )
 
-var descriptions map[string]string
-
 func Provider() terraform.ResourceProvider {
 
 	// The actual provider
@@ -111,9 +109,4 @@ func parseToken(token string) string {
 		return token
 	}
 	return "bearer " + token
-}
-func init() {
-	descriptions = map[string]string{
-		"locale": "Set the locale for translation.",
-	}
 }

--- a/provider.go
+++ b/provider.go
@@ -21,55 +21,55 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CF_API", ""),
-				Description: descriptions["api_endpoint"],
+				Description: "Your Cloud Foundry api url.",
 			},
 			"username": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CF_USERNAME", ""),
-				Description: descriptions["username"],
+				Description: "The username of an admin user. (Optional if you use an access token)",
 			},
 			"password": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CF_PASSWORD", ""),
-				Description: descriptions["password"],
+				Description: "The password of an admin user. (Optional if you use an access token)",
 			},
 			"enc_private_key": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CF_ENC_PRIVATE_KEY", ""),
-				Description: descriptions["enc_private_key"],
+				Description: "A GPG private key(s) generate from `gpg --export-secret-key -a <real name>` . Need a passphrase with 'enc_passphrase'.",
 			},
 			"enc_passphrase": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CF_ENC_PASSPHRASE", ""),
-				Description: descriptions["enc_passphrase"],
+				Description: "The passphrase for your gpg key.",
 			},
 			"user_refresh_token": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
-				Description: descriptions["user_refresh_token"],
+				Description: "The OAuth refresh token used to refresh your token.",
 			},
 			"user_access_token": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CF_TOKEN", ""),
-				Description: descriptions["user_access_token"],
+				Description: "The OAuth token used to connect to a Cloud Foundry. (Optional if you use 'username' and 'password')",
 			},
 			"verbose": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: descriptions["verbose"],
+				Description: "Set to true to see request sent to Cloud Foundry.",
 			},
 			"skip_ssl_validation": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: descriptions["skip_ssl_validation"],
+				Description: "Set to true to skip verification of the API endpoint. Not recommended!",
 			},
 		},
 
@@ -114,24 +114,6 @@ func parseToken(token string) string {
 }
 func init() {
 	descriptions = map[string]string{
-		"password": "The password of an admin user. (Optional if you use an access token)",
-
-		"username": "The username of an admin user. (Optional if you use an access token)",
-
-		"api_endpoint": "Your Cloud Foundry api url.",
-
-		"user_access_token": "The OAuth token used to connect to a Cloud Foundry. (Optional if you use 'username' and 'password')",
-
-		"user_refresh_token": "The OAuth refresh token used to refresh your token.",
-
 		"locale": "Set the locale for translation.",
-
-		"verbose": "Set to true to see request sent to Cloud Foundry.",
-
-		"skip_ssl_validation": "Set to true to skip verification of the API endpoint. Not recommended!",
-
-		"enc_private_key": "A GPG private key(s) generate from `gpg --export-secret-key -a <real name>` . Need a passphrase with 'enc_passphrase'.",
-
-		"enc_passphrase": "The passphrase for your gpg key.",
 	}
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,0 +1,16 @@
+package main_test
+
+import (
+	. "github.com/orange-cloudfoundry/terraform-provider-cloudfoundry"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+var _ = Describe("Provider", func() {
+	It("should validate", func() {
+		Expect(Provider().(*schema.Provider).InternalValidate()).To(Succeed())
+	})
+})


### PR DESCRIPTION
## Add test to validate Provider

As suggested by: https://www.terraform.io/docs/plugins/provider.html#provider

> As part of the unit tests, you should call InternalValidate. This is used
> to verify the structure of the provider and all of the resources, and
> reports an error if it is invalid.

## Move provider schema descriptions inline

So that it's easier to understand what each option does (without reading
up/down the file) and they are always kept in-sync (turns out that `locale`
was unused).