### PR TITLE
fix on_running check in security group update

### DIFF
--- a/resources/security_groups.go
+++ b/resources/security_groups.go
@@ -195,13 +195,17 @@ func (c CfSecurityGroupResource) Update(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
+	isOnRunning, err := c.isOnRunning(client, d.Id())
+	if err != nil {
+		return err
+	}
 	if d.Get("on_staging").(bool) != isOnStaging {
 		err = c.updateBindingStaging(client, d.Id(), d.Get("on_staging").(bool))
 		if err != nil {
 			return err
 		}
 	}
-	if d.Get("on_running").(bool) != isOnStaging {
+	if d.Get("on_running").(bool) != isOnRunning {
 		err = c.updateBindingRunning(client, d.Id(), d.Get("on_running").(bool))
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR fixes a bug, where the security group update was checking the value of `on_staging` for both `on_staging` and `on_running`.

