### PR TITLE
Update Readme install.sh invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ $ export PROVIDER_CLOUDFOUNDRY_VERSION="v0.8.0"
 #### via curl
 
 ```bash
-$ sh -c "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh)"
+$ bash -c "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/$(echo ${PROVIDER_CLOUDFOUNDRY_VERSION:-master})/bin/install.sh)"
 ```
 
 #### via wget
 
 ```bash
-$ sh -c "$(wget https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh -O -)"
+$ bash -c "$(wget https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/$(echo ${PROVIDER_CLOUDFOUNDRY_VERSION:-master})/bin/install.sh -O -)"
 ```
 
 ### Manually


### PR DESCRIPTION
So that users pick the proper version of the install script that goes with the provider version.

The latest version of install.sh script modified the archive naming making it unsuitable for fetching old version of the providers:

```sh
$ export PROVIDER_CLOUDFOUNDRY_VERSION = 0.7.3
$ sh -xc "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh)"
[...]
Installing terraform-provider-cloudfoundry-v0.7.3...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     9    0     9    0     0     20      0 --:--:-- --:--:-- --:--:--    20
File https://github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/releases/download/v0.7.3/terraform-provider-cloudfoundry_0.9._linux_amd64 not found, so it can't be downloaded.
```

Also moved from sh to bash as this fails on ubuntu 16.04:

```
sh -xc "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh)"
+ REPO_NAME=terraform-provider-cloudfoundry
+ NAME=terraform-provider-cloudfoundry
+ OS=
+ OWNER=orange-cloudfoundry
+ CDPATH=/var:/
+ cd -P tmp
+ : /var/tmp
+ cd -- /var/tmp
+ cd -
/home/guillaume/code/workspaceElPaasov14/terraform-provider-cloudfoundry
+ 
+ [[ 0 != 0 ]]
sh: 11: [[: not found
+ terraform --version
+ which terraform
+ awk {print $2}
/usr/sbin/terraform
+ tf_version=v0.9.6

version
0.10.2.
sh: 15: Bad substitution
```