### PR TITLE
Fix problem on version length

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -11,8 +11,7 @@ which terraform &> /dev/null
 if [[ "$?" != "0" ]]; then
     echo "you must have terraform installed"
 fi
-tf_version=$(terraform --version | awk '{print $2}')
-tf_version=${tf_version:1:4}
+tf_version=$(terraform --version | head -n 1 | cut -d 'v' -f 2 | cut -d '.' -f 1,2)
 
 if [[ "x$PROVIDER_CLOUDFOUNDRY_VERSION" == "x" ]]; then
     VERSION=$(curl -s https://api.github.com/repos/${OWNER}/${REPO_NAME}/releases/latest | grep tag_name | head -n 1 | cut -d '"' -f 4)


### PR DESCRIPTION
Use the '.' separator to extract version rather than a fixed number of characters (which causes problems in v0.9 to v0.10 or v0.10 to v1.0)